### PR TITLE
Bugfix: Setup error handling for when file designated in etIgnore is not present

### DIFF
--- a/src/submission/SubmissionFileBlacklist.js
+++ b/src/submission/SubmissionFileBlacklist.js
@@ -34,11 +34,20 @@ class SubmissionFileBlacklist {
       if (fileLine.startsWith("#") || fileLine.length === 0) {
         return [...globs]
       } else {
-        const fileOrDir = fs.statSync(path.join(this.directory, fileLine))
-        if (fileOrDir.isDirectory()) {
-          fileLine = this._formatDirectoryGlob(fileLine)
+        try {
+          const fileOrDir = fs.statSync(path.join(this.directory, fileLine))
+          // console.log("File exists.");
+
+          if (fileOrDir.isDirectory()) {
+            fileLine = this._formatDirectoryGlob(fileLine)
+          }
+          return [...globs, fileLine]
         }
-        return [...globs, fileLine]
+        catch (error) {
+          // if a file designated etIgnore does not exist, we will get a "Error: ENOENT: no such file or directory,"
+          // skip this line and go to the next
+          return [...globs]
+        }
       }
     }, [])
   }

--- a/src/submission/SubmissionFileBlacklist.js
+++ b/src/submission/SubmissionFileBlacklist.js
@@ -34,20 +34,22 @@ class SubmissionFileBlacklist {
       if (fileLine.startsWith("#") || fileLine.length === 0) {
         return [...globs]
       } else {
+        let fileOrDir
         try {
-          const fileOrDir = fs.statSync(path.join(this.directory, fileLine))
-          // console.log("File exists.");
-
-          if (fileOrDir.isDirectory()) {
-            fileLine = this._formatDirectoryGlob(fileLine)
-          }
-          return [...globs, fileLine]
+         fileOrDir = fs.statSync(path.join(this.directory, fileLine))
         }
         catch (error) {
-          // if a file designated etIgnore does not exist, we will get a "Error: ENOENT: no such file or directory,"
-          // skip this line and go to the next
-          return [...globs]
+          if (error.code === "ENOENT"){
+            return globs
+          } else {
+            throw error
+          }
         }
+        // no error occurred in stating the directory, so add it
+        if (fileOrDir && fileOrDir.isDirectory()) {
+          fileLine = this._formatDirectoryGlob(fileLine)
+        }
+        return [...globs, fileLine]
       }
     }, [])
   }

--- a/test/fixtures/bloated-challenge/.etignore
+++ b/test/fixtures/bloated-challenge/.etignore
@@ -2,3 +2,5 @@ bloated-challenge.md
 
 # Here's a comment
 /rando_folder
+
+test.md


### PR DESCRIPTION
- Added try...catch block for when `ENOENT: no such file or directory` error occurs during processing of blacklisted file paths

@dpickett FYI: After looking at it multiple ways, **I couldn't see the value in a test:**
- the expected final result stays exactly the same regardless of the test fixture
- couldn't see the value in testing that an error is not thrown, unless I made a more contrived fixture that had an erroneous file path, and one that didn't. I DID add an erroneous file path to the fixture that is already in use however, so it is controlling for that functionality 
- for all other errors, I didnt see value in testing, because then I would have to edit the code to force an error to be thrown when running fs.statSync()

Let me know if there is feedback to better test though. 

Doesn't look like there is a way to test a branch of et-node, so I will click test after the merge (unless there is a better workflow for deployment) 